### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ console.log(
   jaccard.index(a, b)
 );
 
-// 0.4
+// 0.2
 ````
 
 Or asynchronously:
@@ -57,7 +57,7 @@ Or asynchronously:
 ````javascript
 jaccard.index(a, b, console.log);
 
-// 0.4
+// 0.2
 ````
 
 ##license


### PR DESCRIPTION
If we have sets a and b, where a = ['1', '2', '3']; and b = ['3', '4', '5']; then (a ^ b) = {'1'} and (a U b) = {'1', '2', '3', '4', '5'}. Then | (a ^ b) | = 1 and | (a U b) | = 5, therefore | (a ^ b) | / | (a U b) | = 0.2, not 0.4.
